### PR TITLE
1906-lox-expression-parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,21 @@
 An implementation of both tree walking and bytecode interpreters from the books by Thorsten Ball and Robert Nystrom.
 
 All the code is very messy and has never been refactored / cleaned up. The purpose of these projects is to get a basic understanding of interpreters and language design before creating my own hobby language.
+
+## Language
+
+So I don't forget, a list of potential features I'd like to consider for my own toy language:
+
+* Errors as values
+* Error productions & Python-esque formatting
+* Ternary
+* Linux/Mac/Windows keywords, e.g. `fn linux function() {}`
+* Statically typed
+* Some concept of a standard library
+* `defer` and `comptime` keywords from Zig
+* Generics
+* Async
+* LSP/Formatter
+* Destructuring
+* Optional chaining
+* Switch 

--- a/lox-tree-walker/lox/ast.py
+++ b/lox-tree-walker/lox/ast.py
@@ -1,45 +1,47 @@
 from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING
 
-from lox.lexer import Token
-from lox.visitors import Visitor
+if TYPE_CHECKING:
+    from lox.lexer import Token
+    from lox.visitors import Visitor
 
 
 class Expression(ABC):
     @abstractmethod
-    def accept(self, visitor: Visitor):
+    def accept(self, visitor: "Visitor"):
         raise NotImplementedError()
 
 
 class Unary(Expression):
-    def __init__(self, operator: Token, right: Expression):
+    def __init__(self, operator: "Token", right: Expression):
         self.operator = operator
         self.right = right
-        
-    def accept(self, visitor: Visitor):
+
+    def accept(self, visitor: "Visitor"):
         return visitor.visitUnaryExpression(self)
-    
+
 
 class Literal(Expression):
     def __init__(self, value):
         self.value = value
-        
-    def accept(self, visitor: Visitor):
+
+    def accept(self, visitor: "Visitor"):
         return visitor.visitLiteralExpression(self)
-    
+
 
 class Grouping(Expression):
     def __init__(self, expr: Expression):
         self.expr = expr
-        
-    def accept(self, visitor: Visitor):
+
+    def accept(self, visitor: "Visitor"):
         return visitor.visitGroupingExpression(self)
-    
+
 
 class Binary(Expression):
-    def __init__(self, left: Expression, token: Token, right: Expression):
+    def __init__(self, left: Expression, token: "Token", right: Expression):
         self.left = left
         self.token = token
         self.right = right
-        
-    def accept(self, visitor: Visitor):
+
+    def accept(self, visitor: "Visitor"):
         return visitor.visitBinaryExpression(self)

--- a/lox-tree-walker/lox/lox.py
+++ b/lox-tree-walker/lox/lox.py
@@ -1,5 +1,6 @@
 from lox.lexer import Lexer, Token
-
+from lox.parser import Parser
+from lox.visitors import TreePrinter
 
 class Lox:
     had_error: bool = False
@@ -9,8 +10,11 @@ class Lox:
         lexer = Lexer(source)
         tokens: list[Token] = lexer.read_tokens()
 
-        for token in tokens:
-            print(token)
+        parser = Parser(tokens)
+        program = parser.expression()
+
+        print(program.accept(TreePrinter()))
+
 
     @staticmethod
     def start_repl():

--- a/lox-tree-walker/lox/lox.py
+++ b/lox-tree-walker/lox/lox.py
@@ -2,6 +2,7 @@ from lox.lexer import Lexer, Token
 from lox.parser import Parser
 from lox.visitors import TreePrinter
 
+
 class Lox:
     had_error: bool = False
 
@@ -11,10 +12,12 @@ class Lox:
         tokens: list[Token] = lexer.read_tokens()
 
         parser = Parser(tokens)
-        program = parser.expression()
+        program = parser.parse()
 
+        if Lox.had_error:
+            return
+        
         print(program.accept(TreePrinter()))
-
 
     @staticmethod
     def start_repl():
@@ -29,10 +32,6 @@ class Lox:
                 break
 
     @staticmethod
-    def error(line: int, message: str):
-        Lox._report(line, "", message)
-
-    @staticmethod
-    def _report(line: int, where: str, message: str):
-        print(f"[line {line}] Error {where}: {message}")
+    def error(line: int, message: str, where: str = ""):
+        print(f"[line {line}] Error{where}: {message}")
         Lox.had_error = True

--- a/lox-tree-walker/lox/parser.py
+++ b/lox-tree-walker/lox/parser.py
@@ -1,0 +1,136 @@
+import lox.ast as ast
+from lox.lexer import Token, TokenType
+
+
+class Parser:
+    """
+    This parser aligns identically with the natural manual parsing
+    of an unambiguous regular grammar.
+
+    The job of a parser is to find the composition of grammar rules
+    which produced the given string. Precedence and associativty
+    are baked into an unambiguous grammar by parsing 'top-down',
+    providing the opportunity to match low precedence operators
+    early, placing them higher in the tree.
+
+    This parser aligns closely with that grammar definition.
+    It is very inefficient however; to parse a literal, you must
+    call expression(), equality(), ..., unary(), primary().
+    """
+
+    def __init__(self, tokens: list[Token]):
+        self.tokens = tokens
+        self.current = 0
+
+    def expression(self) -> ast.Expression:
+        return self.equality()
+
+    def equality(self) -> ast.Expression:
+        expr = self.comparison()
+
+        while self.match([TokenType.BANG_EQUAL, TokenType.EQUAL_EQUAL]):
+            operator = self.previous()
+            right = self.equality()
+
+            expr = ast.Binary(expr, operator, right)
+
+        return expr
+
+    def comparison(self) -> ast.Expression:
+        expr = self.term()
+
+        while self.match(
+            [
+                TokenType.LESS,
+                TokenType.LESS_EQUAL,
+                TokenType.GREATER,
+                TokenType.GREATER_EQUAL,
+            ]
+        ):
+            operator = self.previous()
+            right = self.comparison()
+
+            expr = ast.Binary(expr, operator, right)
+
+        return expr
+
+    def term(self) -> ast.Expression:
+        expr = self.factor()
+
+        while self.match([TokenType.PLUS, TokenType.MINUS]):
+            operator = self.previous()
+            right = self.term()
+
+            expr = ast.Binary(expr, operator, right)
+
+        return expr
+
+    def factor(self) -> ast.Expression:
+        expr = self.unary()
+
+        while self.match([TokenType.STAR, TokenType.SLASH]):
+            operator = self.previous()
+            right = self.term()
+
+            expr = ast.Binary(expr, operator, right)
+
+        return expr
+
+    def unary(self) -> ast.Expression:
+        if self.match([TokenType.BANG, TokenType.MINUS]):
+            operator = self.previous()
+            right = self.unary()
+
+            return ast.Unary(operator, right)
+
+        return self.primary()
+
+    def primary(self) -> ast.Expression:
+        if self.match([TokenType.TRUE]):
+            return ast.Literal(True)
+        elif self.match([TokenType.FALSE]):
+            return ast.Literal(False)
+        elif self.match([TokenType.NIL]):
+            return ast.Literal(None)
+
+        if self.match([TokenType.NUMBER, TokenType.STRING]):
+            return ast.Literal(self.previous().literal)
+
+        if self.match([TokenType.LEFT_PAREN]):
+            expr = self.expression()
+            self.consume(TokenType.RIGHT_PAREN, "Expected ')' after expression.")
+            return ast.Grouping(expr)
+
+        return ast.Literal(None)  # never hit. make pylance shhhh
+
+    def match(self, token_types: list[TokenType]) -> bool:
+        for type in token_types:
+            if self.check(type):
+                self.advance()
+                return True
+
+        return False
+
+    def check(self, type: TokenType) -> bool:
+        if self.is_at_end():
+            return False
+
+        return self.peek().type == type
+
+    def advance(self) -> Token:
+        if not self.is_at_end():
+            self.current += 1
+
+        return self.previous()
+
+    def is_at_end(self) -> bool:
+        return self.peek() == TokenType.EOF
+
+    def peek(self) -> Token:
+        return self.tokens[self.current]
+
+    def previous(self) -> Token:
+        return self.tokens[self.current - 1]
+
+    def consume(self, expected: TokenType, error_message: str):
+        pass

--- a/lox-tree-walker/lox/parser.py
+++ b/lox-tree-walker/lox/parser.py
@@ -85,7 +85,7 @@ class Parser:
 
         while self.match([TokenType.STAR, TokenType.SLASH]):
             operator = self.previous()
-            right = self.term()
+            right = self.factor()
 
             expr = ast.Binary(expr, operator, right)
 

--- a/lox-tree-walker/lox/parser.py
+++ b/lox-tree-walker/lox/parser.py
@@ -1,5 +1,10 @@
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from lox.lexer import Token
+
 import lox.ast as ast
-from lox.lexer import Token, TokenType
+from lox.lexer import TokenType
 
 
 class Parser:
@@ -18,14 +23,14 @@ class Parser:
     call expression(), equality(), ..., unary(), primary().
     """
 
-    def __init__(self, tokens: list[Token]):
+    def __init__(self, tokens: list["Token"]):
         self.tokens = tokens
         self.current = 0
 
-    def expression(self) -> ast.Expression:
+    def expression(self) -> "ast.Expression":
         return self.equality()
 
-    def equality(self) -> ast.Expression:
+    def equality(self) -> "ast.Expression":
         expr = self.comparison()
 
         while self.match([TokenType.BANG_EQUAL, TokenType.EQUAL_EQUAL]):
@@ -36,7 +41,7 @@ class Parser:
 
         return expr
 
-    def comparison(self) -> ast.Expression:
+    def comparison(self) -> "ast.Expression":
         expr = self.term()
 
         while self.match(
@@ -54,7 +59,7 @@ class Parser:
 
         return expr
 
-    def term(self) -> ast.Expression:
+    def term(self) -> "ast.Expression":
         expr = self.factor()
 
         while self.match([TokenType.PLUS, TokenType.MINUS]):
@@ -65,7 +70,7 @@ class Parser:
 
         return expr
 
-    def factor(self) -> ast.Expression:
+    def factor(self) -> "ast.Expression":
         expr = self.unary()
 
         while self.match([TokenType.STAR, TokenType.SLASH]):
@@ -76,7 +81,7 @@ class Parser:
 
         return expr
 
-    def unary(self) -> ast.Expression:
+    def unary(self) -> "ast.Expression":
         if self.match([TokenType.BANG, TokenType.MINUS]):
             operator = self.previous()
             right = self.unary()
@@ -85,7 +90,7 @@ class Parser:
 
         return self.primary()
 
-    def primary(self) -> ast.Expression:
+    def primary(self) -> "ast.Expression":
         if self.match([TokenType.TRUE]):
             return ast.Literal(True)
         elif self.match([TokenType.FALSE]):
@@ -103,7 +108,7 @@ class Parser:
 
         return ast.Literal(None)  # never hit. make pylance shhhh
 
-    def match(self, token_types: list[TokenType]) -> bool:
+    def match(self, token_types: list["TokenType"]) -> bool:
         for type in token_types:
             if self.check(type):
                 self.advance()
@@ -111,13 +116,13 @@ class Parser:
 
         return False
 
-    def check(self, type: TokenType) -> bool:
+    def check(self, type: "TokenType") -> bool:
         if self.is_at_end():
             return False
 
         return self.peek().type == type
 
-    def advance(self) -> Token:
+    def advance(self) -> "Token":
         if not self.is_at_end():
             self.current += 1
 
@@ -126,11 +131,11 @@ class Parser:
     def is_at_end(self) -> bool:
         return self.peek() == TokenType.EOF
 
-    def peek(self) -> Token:
+    def peek(self) -> "Token":
         return self.tokens[self.current]
 
-    def previous(self) -> Token:
+    def previous(self) -> "Token":
         return self.tokens[self.current - 1]
 
-    def consume(self, expected: TokenType, error_message: str):
+    def consume(self, expected: "TokenType", error_message: str):
         pass

--- a/lox-tree-walker/lox/visitors/tree_printer.py
+++ b/lox-tree-walker/lox/visitors/tree_printer.py
@@ -1,18 +1,25 @@
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import lox.ast as ast
+
 from lox.visitors import Visitor
-import lox.ast as ast
+
 
 class TreePrinter(Visitor):
-    def print(self, expr: ast.Expression):
+    def print(self, expr: "ast.Expression"):
         return expr.accept(self)
 
-    def visitUnaryExpression(self, expr: ast.Unary) -> str:
+    def visitUnaryExpression(self, expr: "ast.Unary") -> str:
         return f"{expr.operator.raw}({expr.right.accept(self)})"
 
-    def visitLiteralExpression(self, expr: ast.Literal) -> str:
+    def visitLiteralExpression(self, expr: "ast.Literal") -> str:
         return str(expr.value)
 
-    def visitGroupingExpression(self, expr: ast.Grouping) -> str:
+    def visitGroupingExpression(self, expr: "ast.Grouping") -> str:
         return f"(group: {expr.expr.accept(self)})"
 
-    def visitBinaryExpression(self, expr: ast.Binary) -> str:
-        return f"({expr.left.accept(self)} {expr.token.raw} ({expr.right.accept(self)}))"
+    def visitBinaryExpression(self, expr: "ast.Binary") -> str:
+        return (
+            f"({expr.left.accept(self)} {expr.token.raw} ({expr.right.accept(self)}))"
+        )

--- a/lox-tree-walker/lox/visitors/visitor.py
+++ b/lox-tree-walker/lox/visitors/visitor.py
@@ -1,21 +1,23 @@
 from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING
 
-import lox.ast as ast
+if TYPE_CHECKING:
+    import lox.ast as ast
 
 
 class Visitor(ABC):
     @abstractmethod
-    def visitUnaryExpression(self, expr: ast.Unary):
+    def visitUnaryExpression(self, expr: "ast.Unary"):
         raise NotImplementedError()
 
     @abstractmethod
-    def visitLiteralExpression(self, expr: ast.Literal):
+    def visitLiteralExpression(self, expr: "ast.Literal"):
         raise NotImplementedError()
 
     @abstractmethod
-    def visitGroupingExpression(self, expr: ast.Grouping):
+    def visitGroupingExpression(self, expr: "ast.Grouping"):
         raise NotImplementedError()
 
     @abstractmethod
-    def visitBinaryExpression(self, expr: ast.Binary):
+    def visitBinaryExpression(self, expr: "ast.Binary"):
         raise NotImplementedError()


### PR DESCRIPTION
Implement parsing of basic numeric expressions, i.e. unary through to binary expressions. Update the REPL to print the parsed input. 

Reworked some of the imports and switched to double quotes for type hints. I'm yet to figure out how to prevent circular imports with Python other than doing this.